### PR TITLE
Fix publicPath for GitHub pages purposes

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -22,7 +22,7 @@ module.exports = {
   output: {
     path: path.resolve('dist'),
     filename: '[name].[hash].js',
-    publicPath: '/',
+    publicPath: '',
   },
 
   plugins: [


### PR DESCRIPTION
Bez poniższej zmiany wykonanie pierwszego zadania domowego (https://github.com/daftcode/frontend_levelup_2018/blob/master/01b_zadanie_domowe.md) nie było możliwe - budowany index.html zawierał ścieżki odnoszące się do root-a strony typu

```html
<link href="/main.css" rel="stylesheet"></head>
...
<script type="text/javascript" src="/main.e9a914a1ba53ca90f7e2.js"></script></body>
```

co po wystawieniu strony za pomocą GitHub pages pod adresem typu https://mwpro.github.io/daftcode-react-starter/ powodowało oczywiście nieładowanie się css-ów i js-ów.